### PR TITLE
Make standard VM image provision Ruby 1.9.3 instead of 1.9.2

### DIFF
--- a/config/worker.standard.yml
+++ b/config/worker.standard.yml
@@ -1,9 +1,9 @@
 base: http://files.travis-ci.org/boxes/bases/oneiric32_base.box
 json:
   rvm:
-    default: 1.9.2
+    default: 1.9.3
     rubies:
-    - name: 1.9.2
+    - name: 1.9.3
     gems:
       - bundler
       - rake


### PR DESCRIPTION
See issue #4 for background. @joshk seems to feel positive about this. @svenfuchs, @rkh, @roidrage — what do you say?
