### PR TITLE
Explicitly specify 1.8 when installing jruby-18mode

### DIFF
--- a/config/worker.ruby.yml
+++ b/config/worker.ruby.yml
@@ -12,7 +12,9 @@ json:
       using: 1.9.3
       check_for: rbx-head-d19
     - name: 1.8.7
-    - name: jruby
+    - name: jruby-d18
+      arguments: --18
+      check_for: jruby-d18
     - name: jruby-d19
       arguments: --19
       check_for: jruby-d19
@@ -29,7 +31,7 @@ json:
       rbx: rbx-head
       rbx-18mode: rbx-head
       rbx-19mode: rbx-head-d19
-      jruby-18mode: jruby
+      jruby-18mode: jruby-d18
       jruby-19mode: jruby-d19
       "2.0": "ruby-2.0.0-preview1"
 recipes:

--- a/config/worker.ruby.yml
+++ b/config/worker.ruby.yml
@@ -33,6 +33,7 @@ json:
       rbx-19mode: rbx-head-d19
       jruby-18mode: jruby-d18
       jruby-19mode: jruby-d19
+      jruby: jruby-19mode
       "2.0": "ruby-2.0.0-preview1"
 recipes:
   - sweeper


### PR DESCRIPTION
Noticed this when running a build for resque

https://travis-ci.org/defunkt/resque/jobs/3498628

```
$ rvm use jruby-18mode
$ ruby --version
jruby 1.7.0 (1.9.3p203) 2012-10-22 ff1ebbe on Java HotSpot(TM) Server VM 1.7.0_09-b05 [linux-i386]
```

The default for rvm 1.17 when installing jruby is to build as 1.9.3.

This change just explicitly uses `--18` when installing `jruby` and renames it `jruby-d18`.
