### PR TITLE
bundler symbol source is deprecated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'thor',           '~> 0.14.6'
 


### PR DESCRIPTION
message from bundler:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
