### PR TITLE
Alias 'rbx' to 'rbx-weekly-d18'

### DIFF
--- a/config/worker.ruby-pro.yml
+++ b/config/worker.ruby-pro.yml
@@ -26,7 +26,7 @@ json:
       - bundler
       - rake
     aliases:
-      rbx: rbx-head
+      rbx: rbx-weekly-d18
       rbx-18mode: rbx-head
       rbx-19mode: rbx-head-d19
       jruby-18mode: jruby

--- a/config/worker.ruby.yml
+++ b/config/worker.ruby.yml
@@ -20,6 +20,7 @@ json:
       - bundler
       - rake
     aliases:
+      rbx: rbx-weekly-d18
       jruby-18mode: jruby-d18
       jruby-19mode: jruby-d19
       jruby: jruby-19mode


### PR DESCRIPTION
This was requested in travis-ci/travis-build#89

From that issue:

> This is the most similar given the old defaults on Travis (ie, Rubinius
> defaults to 1.8 mode and Travis was updated every few weeks with a build
> of the Rubinius 2.0.testing branch).

/cc @joshk
